### PR TITLE
Bump template validator to 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "lint-staged": "^9.5.0",
         "prettier": "^1.19.1",
         "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0",
-        "q-template-validator": "github:CriminalInjuriesCompensationAuthority/q-template-validator#v0.0.2"
+        "q-template-validator": "github:CriminalInjuriesCompensationAuthority/q-template-validator#v0.0.3"
     },
     "dependencies": {}
 }


### PR DESCRIPTION
Template validator v0.0.3 adds the ability to pass in custom formats e.g.

https://github.com/CriminalInjuriesCompensationAuthority/q-template-validator/blob/1bab8c847e51c0bb57e68d98b9652692a4c78cb6/index.test.js#L21