### PR TITLE
Bump q template validator

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,7 @@
 /*! m0-start */
 const config = {
     '*.js': ['eslint --fix --color', 'git add'],
-    '*.json': ['prettier --write', 'git add']
+    '*.{json,yml,yaml}': ['prettier --write', 'git add']
 };
 /*! m0-end */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "q-template-application",
+    "name": "q-templates-application",
     "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
@@ -203,9 +203,9 @@
             },
             "dependencies": {
                 "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
                 }
             }
@@ -859,9 +859,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-                    "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
                     "dev": true
                 }
             }
@@ -912,7 +912,28 @@
             "dev": true,
             "requires": {
                 "google-libphonenumber": "^3.2.7",
-                "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#422966d36b16ac434497b57451e4bc426e70e36f"
+                "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0"
+            },
+            "dependencies": {
+                "module-zero": {
+                    "version": "github:webstacker/module-zero#22a0fa68b7160fdab0cb2cdf3c266effc11ed39a",
+                    "from": "github:webstacker/module-zero#v0.6.1",
+                    "dev": true,
+                    "requires": {
+                        "detect-newline": "^3.1.0",
+                        "fs-extra": "^8.1.0",
+                        "globby": "^11.0.0",
+                        "write-pkg": "^4.0.0"
+                    }
+                },
+                "q-base-config": {
+                    "version": "github:CriminalInjuriesCompensationAuthority/q-base-config#422966d36b16ac434497b57451e4bc426e70e36f",
+                    "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0",
+                    "dev": true,
+                    "requires": {
+                        "module-zero": "github:webstacker/module-zero#v0.6.1"
+                    }
+                }
             }
         },
         "ansi-escapes": {
@@ -2766,7 +2787,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2787,12 +2809,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2807,17 +2831,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2934,7 +2961,8 @@
                 "inherits": {
                     "version": "2.0.4",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2946,6 +2974,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2960,6 +2989,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2967,12 +2997,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.9.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2991,6 +3023,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3080,7 +3113,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3092,6 +3126,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3177,7 +3212,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3213,6 +3249,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3232,6 +3269,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3275,12 +3313,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -3385,9 +3425,9 @@
             }
         },
         "globby": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-            "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+            "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
             "dev": true,
             "requires": {
                 "array-union": "^2.1.0",
@@ -5087,7 +5127,7 @@
             "dev": true
         },
         "json-rules": {
-            "version": "git+https://github.com/webstacker/json-rules.git#794d98f1a42316c4e62c2efe76bcb9be8a2944d7",
+            "version": "git+https://github.com/webstacker/json-rules.git#ea09a0ae33437b985d20af683577a5a1f31d834a",
             "from": "git+https://github.com/webstacker/json-rules.git",
             "dev": true
         },
@@ -5125,9 +5165,9 @@
             },
             "dependencies": {
                 "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
                 }
             }
@@ -5773,9 +5813,9 @@
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
         "mixin-deep": {
@@ -5800,17 +5840,17 @@
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "dev": true,
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
             }
         },
         "module-zero": {
-            "version": "github:webstacker/module-zero#22a0fa68b7160fdab0cb2cdf3c266effc11ed39a",
-            "from": "github:webstacker/module-zero#v0.6.1",
+            "version": "github:webstacker/module-zero#3fd45807112efd797792ad0dcda64cc0d064a262",
+            "from": "github:webstacker/module-zero#v0.8.0",
             "dev": true,
             "requires": {
                 "detect-newline": "^3.1.0",
@@ -5820,9 +5860,9 @@
             }
         },
         "moment": {
-            "version": "2.24.0",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+            "version": "2.27.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+            "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
             "dev": true
         },
         "ms": {
@@ -6356,11 +6396,11 @@
             "dev": true
         },
         "q-base-config": {
-            "version": "github:CriminalInjuriesCompensationAuthority/q-base-config#422966d36b16ac434497b57451e4bc426e70e36f",
-            "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0",
+            "version": "github:CriminalInjuriesCompensationAuthority/q-base-config#a216f1ace9b37330ca0f957a157dd73f43614bb7",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.9.0",
             "dev": true,
             "requires": {
-                "module-zero": "github:webstacker/module-zero#22a0fa68b7160fdab0cb2cdf3c266effc11ed39a"
+                "module-zero": "github:webstacker/module-zero#v0.8.0"
             }
         },
         "q-router": {
@@ -6368,7 +6408,7 @@
             "from": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
             "dev": true,
             "requires": {
-                "json-rules": "git+https://github.com/webstacker/json-rules.git#794d98f1a42316c4e62c2efe76bcb9be8a2944d7",
+                "json-rules": "git+https://github.com/webstacker/json-rules.git",
                 "moment": "^2.24.0"
             }
         },
@@ -6377,7 +6417,28 @@
             "from": "github:CriminalInjuriesCompensationAuthority/q-schema#v1.0.0",
             "dev": true,
             "requires": {
-                "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#422966d36b16ac434497b57451e4bc426e70e36f"
+                "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0"
+            },
+            "dependencies": {
+                "module-zero": {
+                    "version": "github:webstacker/module-zero#22a0fa68b7160fdab0cb2cdf3c266effc11ed39a",
+                    "from": "github:webstacker/module-zero#v0.6.1",
+                    "dev": true,
+                    "requires": {
+                        "detect-newline": "^3.1.0",
+                        "fs-extra": "^8.1.0",
+                        "globby": "^11.0.0",
+                        "write-pkg": "^4.0.0"
+                    }
+                },
+                "q-base-config": {
+                    "version": "github:CriminalInjuriesCompensationAuthority/q-base-config#422966d36b16ac434497b57451e4bc426e70e36f",
+                    "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0",
+                    "dev": true,
+                    "requires": {
+                        "module-zero": "github:webstacker/module-zero#v0.6.1"
+                    }
+                }
             }
         },
         "q-template-validator": {
@@ -6389,8 +6450,8 @@
                 "ajv-errors": "^1.0.1",
                 "lodash.get": "^4.4.2",
                 "lodash.has": "^4.5.2",
-                "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#5f64e1645797f59c8d9eb672f9f426d0d3dbd27c",
-                "q-schema": "github:CriminalInjuriesCompensationAuthority/q-schema#00f8f0fc404975ac032302d722cd444c6e597852"
+                "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
+                "q-schema": "github:CriminalInjuriesCompensationAuthority/q-schema#v1.0.0"
             }
         },
         "qs": {
@@ -6783,9 +6844,9 @@
                     }
                 },
                 "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
                 },
                 "to-regex-range": {
@@ -8023,9 +8084,9 @@
             }
         },
         "yargs-parser": {
-            "version": "13.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-            "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+            "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
             "dev": true,
             "requires": {
                 "camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5107,9 +5107,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.7.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "version": "5.7.4",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+                    "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
                     "dev": true
                 }
             }
@@ -5127,8 +5127,8 @@
             "dev": true
         },
         "json-rules": {
-            "version": "git+https://github.com/webstacker/json-rules.git#ea09a0ae33437b985d20af683577a5a1f31d834a",
-            "from": "git+https://github.com/webstacker/json-rules.git",
+            "version": "github:webstacker/json-rules#ea09a0ae33437b985d20af683577a5a1f31d834a",
+            "from": "github:webstacker/json-rules#v0.3.0",
             "dev": true
         },
         "json-schema": {
@@ -6404,11 +6404,11 @@
             }
         },
         "q-router": {
-            "version": "github:CriminalInjuriesCompensationAuthority/q-router#5f64e1645797f59c8d9eb672f9f426d0d3dbd27c",
-            "from": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
+            "version": "github:CriminalInjuriesCompensationAuthority/q-router#6ec5a28346bd5d3882b421edf0df6fdad137b123",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.0",
             "dev": true,
             "requires": {
-                "json-rules": "git+https://github.com/webstacker/json-rules.git",
+                "json-rules": "github:webstacker/json-rules#v0.3.0",
                 "moment": "^2.24.0"
             }
         },
@@ -6442,15 +6442,15 @@
             }
         },
         "q-template-validator": {
-            "version": "github:CriminalInjuriesCompensationAuthority/q-template-validator#1bab8c847e51c0bb57e68d98b9652692a4c78cb6",
-            "from": "github:CriminalInjuriesCompensationAuthority/q-template-validator#v0.0.3",
+            "version": "github:CriminalInjuriesCompensationAuthority/q-template-validator#fb44edbbb230f534338610d91b7a2282d15fe8d8",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-template-validator#v1.0.0",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.0",
                 "ajv-errors": "^1.0.1",
                 "lodash.get": "^4.4.2",
                 "lodash.has": "^4.5.2",
-                "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
+                "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.0",
                 "q-schema": "github:CriminalInjuriesCompensationAuthority/q-schema#v1.0.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
             ".huskyrc.js",
             ".lintstagedrc.js",
             ".prettierrc.js",
-            "jest.config.js",
-            ".gitignore"
+            ".gitignore",
+            "jest.config.js"
         ],
         "files": [
             ".editorconfig",
@@ -53,7 +53,7 @@
         "jest": "^24.9.0",
         "lint-staged": "^9.5.0",
         "prettier": "^1.19.1",
-        "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0",
+        "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.9.0",
         "q-template-validator": "github:CriminalInjuriesCompensationAuthority/q-template-validator#v0.0.3"
     },
     "dependencies": {}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "lint-staged": "^9.5.0",
         "prettier": "^1.19.1",
         "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.9.0",
-        "q-template-validator": "github:CriminalInjuriesCompensationAuthority/q-template-validator#v0.0.3"
+        "q-template-validator": "github:CriminalInjuriesCompensationAuthority/q-template-validator#v1.0.0"
     },
     "dependencies": {}
 }


### PR DESCRIPTION
* Bump q-base-config to 0.9.0. Addresses some module security issues
* Bump q-template-validator to 1.0.0. Allows routing that uses answer arrays to be tested.

@BarryPiccinni @armoj - I ran the test(s) and it was taking ~17 seconds to complete on my machine. Was that similar to before?