### PR TITLE
Fix hint text on physical-injury schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -4511,13 +4511,13 @@ module.exports = {
         'p-applicant-physical-injury': {
             schema: {
                 $schema: 'http://json-schema.org/draft-07/schema#',
-                description: 'Select all that apply.',
                 type: 'object',
                 required: ['q-applicant-physical-injury'],
                 additionalProperties: false,
                 properties: {
                     'q-applicant-physical-injury': {
                         title: 'What was injured?',
+                        description: 'Select all that apply.',
                         type: 'array',
                         items: {
                             anyOf: [


### PR DESCRIPTION
Moves the `description` property to be under a child of the `properties` property. The transformer will now pick this description up and render it as expected.