### PR TITLE
Add meta properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "q-templates-application",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-templates-application",
-    "version": "5.0.0",
+    "version": "5.1.0",
     "description": "Apply for compensation questionnaire template",
     "main": "dist/template.json",
     "scripts": {

--- a/src/template.js
+++ b/src/template.js
@@ -881,6 +881,9 @@ module.exports = {
                 allOf: [
                     {
                         title: 'Where in England did it happen?',
+                        meta: {
+                            id: 'crime-location-england'
+                        },
                         required: [
                             'q-applicant-english-town-or-city',
                             'q-applicant-english-location'

--- a/src/template.js
+++ b/src/template.js
@@ -712,9 +712,19 @@ module.exports = {
                 additionalProperties: false,
                 properties: {
                     'q-applicant-when-did-the-crime-stop': {
+                        title: 'When did it stop?',
+                        meta: {
+                            keywords: {
+                                format: {
+                                    precision: 'YYYY-MM',
+                                    defaults: {
+                                        DD: '01'
+                                    }
+                                }
+                            }
+                        },
                         type: 'string',
                         format: 'date-time',
-                        title: 'When did it stop?',
                         description: 'For example, 03 2020. You can enter an approximate date.',
                         errorMessage: {
                             format: 'Enter the date the crime stopped and include a month and year'

--- a/src/template.js
+++ b/src/template.js
@@ -4069,6 +4069,9 @@ module.exports = {
                 allOf: [
                     {
                         title: "What is the dentist's address?",
+                        meta: {
+                            id: 'applicant-dentist-address'
+                        },
                         required: [
                             'q-applicant-dentist-address-building-and-street',
                             'q-applicant-dentist-address-town-or-city',

--- a/src/template.js
+++ b/src/template.js
@@ -965,6 +965,9 @@ module.exports = {
                 allOf: [
                     {
                         title: 'Where in Scotland did it happen?',
+                        meta: {
+                            id: 'crime-location-scotland'
+                        },
                         required: [
                             'q-applicant-scottish-town-or-city',
                             'q-applicant-scottish-location'

--- a/src/template.js
+++ b/src/template.js
@@ -660,9 +660,19 @@ module.exports = {
                 additionalProperties: false,
                 properties: {
                     'q-applicant-when-did-the-crime-start': {
+                        title: 'When did it start?',
+                        meta: {
+                            keywords: {
+                                format: {
+                                    precision: 'YYYY-MM',
+                                    defaults: {
+                                        DD: '01'
+                                    }
+                                }
+                            }
+                        },
                         type: 'string',
                         format: 'date-time',
-                        title: 'When did it start?',
                         description: 'For example, 02 2020. You can enter an approximate date.',
                         errorMessage: {
                             format: 'Enter the date the crime started and include a month and year'

--- a/src/template.js
+++ b/src/template.js
@@ -13007,6 +13007,11 @@ module.exports = {
                     }
                 }
             ]
+        },
+        attributes: {
+            'q-applicant-physical-injuries': {
+                title: 'What was injured?'
+            }
         }
     }
 };

--- a/src/template.js
+++ b/src/template.js
@@ -1913,6 +1913,9 @@ module.exports = {
                 allOf: [
                     {
                         title: 'Enter your name',
+                        meta: {
+                            id: 'applicant-name'
+                        },
                         required: [
                             'q-applicant-title',
                             'q-applicant-first-name',

--- a/src/template.js
+++ b/src/template.js
@@ -2129,9 +2129,16 @@ module.exports = {
                 additionalProperties: false,
                 properties: {
                     'q-applicant-enter-your-date-of-birth': {
+                        title: 'Enter your date of birth',
+                        meta: {
+                            keywords: {
+                                format: {
+                                    precision: 'YYYY-MM-DD'
+                                }
+                            }
+                        },
                         type: 'string',
                         format: 'date-time',
-                        title: 'Enter your date of birth',
                         description: 'For example, 31 3 1980.',
                         errorMessage: {
                             format: 'Enter your date of birth and include a day, month and year'

--- a/src/template.js
+++ b/src/template.js
@@ -2158,6 +2158,9 @@ module.exports = {
                 allOf: [
                     {
                         title: 'Enter your address',
+                        meta: {
+                            id: 'applicant-address'
+                        },
                         required: ['q-applicant-building-and-street', 'q-applicant-town-or-city'],
                         propertyNames: {
                             enum: [

--- a/src/template.js
+++ b/src/template.js
@@ -3879,6 +3879,9 @@ module.exports = {
                 allOf: [
                     {
                         title: "What is the GP's address?",
+                        meta: {
+                            id: 'applicant-gp-address'
+                        },
                         required: [
                             'q-gp-building-and-street',
                             'q-gp-town-or-city',

--- a/src/template.js
+++ b/src/template.js
@@ -607,9 +607,16 @@ module.exports = {
                 additionalProperties: false,
                 properties: {
                     'q-applicant-when-did-the-crime-happen': {
+                        title: 'When did the crime happen?',
+                        meta: {
+                            keywords: {
+                                format: {
+                                    precision: 'YYYY-MM-DD'
+                                }
+                            }
+                        },
                         type: 'string',
                         format: 'date-time',
-                        title: 'When did the crime happen?',
                         description: 'For example, 28 2 2020. You can enter an approximate date.',
                         errorMessage: {
                             format:

--- a/src/template.js
+++ b/src/template.js
@@ -1049,6 +1049,9 @@ module.exports = {
                 allOf: [
                     {
                         title: 'Where in Wales did it happen?',
+                        meta: {
+                            id: 'crime-location-wales'
+                        },
                         required: ['q-applicant-welsh-town-or-city', 'q-applicant-welsh-location'],
                         propertyNames: {
                             enum: ['q-applicant-welsh-town-or-city', 'q-applicant-welsh-location']

--- a/src/template.js
+++ b/src/template.js
@@ -916,7 +916,7 @@ module.exports = {
                     {
                         title: 'Where in England did it happen?',
                         meta: {
-                            id: 'crime-location-england'
+                            compositeId: 'crime-location-england'
                         },
                         required: [
                             'q-applicant-english-town-or-city',
@@ -1000,7 +1000,7 @@ module.exports = {
                     {
                         title: 'Where in Scotland did it happen?',
                         meta: {
-                            id: 'crime-location-scotland'
+                            compositeId: 'crime-location-scotland'
                         },
                         required: [
                             'q-applicant-scottish-town-or-city',
@@ -1084,7 +1084,7 @@ module.exports = {
                     {
                         title: 'Where in Wales did it happen?',
                         meta: {
-                            id: 'crime-location-wales'
+                            compositeId: 'crime-location-wales'
                         },
                         required: ['q-applicant-welsh-town-or-city', 'q-applicant-welsh-location'],
                         propertyNames: {
@@ -1957,7 +1957,7 @@ module.exports = {
                     {
                         title: 'Enter your name',
                         meta: {
-                            id: 'applicant-name'
+                            compositeId: 'applicant-name'
                         },
                         required: [
                             'q-applicant-title',
@@ -2209,7 +2209,7 @@ module.exports = {
                     {
                         title: 'Enter your address',
                         meta: {
-                            id: 'applicant-address'
+                            compositeId: 'applicant-address'
                         },
                         required: ['q-applicant-building-and-street', 'q-applicant-town-or-city'],
                         propertyNames: {
@@ -3930,7 +3930,7 @@ module.exports = {
                     {
                         title: "What is the GP's address?",
                         meta: {
-                            id: 'applicant-gp-address'
+                            compositeId: 'applicant-gp-address'
                         },
                         required: [
                             'q-gp-building-and-street',
@@ -4120,7 +4120,7 @@ module.exports = {
                     {
                         title: "What is the dentist's address?",
                         meta: {
-                            id: 'applicant-dentist-address'
+                            compositeId: 'applicant-dentist-address'
                         },
                         required: [
                             'q-applicant-dentist-address-building-and-street',
@@ -8815,7 +8815,7 @@ module.exports = {
                     {
                         title: 'Where did you have treatment?',
                         meta: {
-                            id: 'applicant-treatment-address'
+                            compositeId: 'applicant-treatment-address'
                         },
                         required: [
                             'q-applicant-treatment-building-and-street',

--- a/src/template.js
+++ b/src/template.js
@@ -8764,6 +8764,9 @@ module.exports = {
                 allOf: [
                     {
                         title: 'Where did you have treatment?',
+                        meta: {
+                            id: 'applicant-treatment-address'
+                        },
                         required: [
                             'q-applicant-treatment-building-and-street',
                             'q-applicant-treatment-town-or-city',

--- a/src/template.js
+++ b/src/template.js
@@ -472,6 +472,13 @@ module.exports = {
                 properties: {
                     'q--when-was-the-crime-reported-to-police': {
                         title: 'When was the crime reported to the police?',
+                        meta: {
+                            keywords: {
+                                format: {
+                                    precision: 'YYYY-MM-DD'
+                                }
+                            }
+                        },
                         type: 'string',
                         format: 'date-time',
                         description: 'For example, 28 2 2020. You can enter an approximate date.',


### PR DESCRIPTION
Add composite IDs for the following composite attributes:

1. `p-applicant-enter-your-name`  >>> `applicant-name`
2. `p-applicant-enter-your-address`  >>> `applicant-address`
3. `p-gp-enter-your-address` >>> `applicant-gp-address`
4. `p-applicant-dentist-address`  >>> `applicant-dentist-address`
5. `p-applicant-treatment-address`  >>> `applicant-treatment-address`
6. `p-applicant-where-in-england-did-it-happen`  >>> `crime-location-england`
7. `p-applicant-where-in-scotland-did-it-happen`  >>> `crime-location-scotland`
8. `p-applicant-where-in-wales-did-it-happen`   >>> `crime-location-wales`

Add precision meta to `date-time` attributes:

1. `q--when-was-the-crime-reported-to-police`
2. `q-applicant-when-did-the-crime-happen`
3. `q-applicant-when-did-the-crime-start`
4. `q-applicant-when-did-the-crime-stop`
5. `q-applicant-enter-your-date-of-birth`

The values for `q-applicant-physical-injuries` are captured over multiple pages. Adds a central location for this attribute's content  / metadata. Can be used for data view purposes.

All changes added in a backwards compatible way. All tests passing.