### PR TITLE
Add contextualised confirmation pages

### DIFF
--- a/src/lib/resource/sections/confirmation.js
+++ b/src/lib/resource/sections/confirmation.js
@@ -1,5 +1,6 @@
 'use strict';
 
+/* eslint-disable no-useless-escape */
 module.exports = {
     section: {
         l10n: {
@@ -27,6 +28,9 @@ module.exports = {
                                     {% else %}
                                       {% set html =  "<p>We\'ll send your confirmation to <strong>" + contactMethod + "</strong> soon</p>" %}
                                     {% endif %}
+                                    {% set contact %}
+                                        {% include 'contact.njk' %}
+                                    {% endset %}
                                     <p class="govuk-body">All links on this page open in a new tab.</p>
                                     {{ govukPanel({
                                       titleText: "Application submitted",
@@ -58,19 +62,16 @@ module.exports = {
                                         <li>you have new information to add to your application</li>
                                         <li>information you provided previously has changed</li>
                                     </ul>
-                                    <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.gov.uk/government/organisations/criminal-injuries-compensation-authority/about-our-services">Send an update about your application</a></p>
+                                    <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://contact-the-cica.form.service.justice.gov.uk/">Send an update about your application</a></p>
                                     <h2 class="govuk-heading-m">Contact us</h2>
-                                    <p class="govuk-body govuk-!-margin-bottom-1">Email: <a href="mailto:info@cica.gov.uk" class="govuk-link">info@cica.gov.uk</a></p>
-                                    {% include \'contact.njk\' %}
-                                    <p class="govuk-body">We will not always send an acknowledgement if you:</p>
-                                      <ul class="govuk-list govuk-list--bullet">
-                                          <li>email us</li>
-                                          <li>write to us</li>
-                                          <li>send us documents</li>
-                                      </ul>
+                                    <p class="govuk-body">As we've only received this application, we will now carry out necessary initial enquiries relating to this. Unless you've anything new to add or update in the application, we kindly ask that you wait for us to contact you.</p>
+                                    {{ govukDetails({
+                                        summaryText: "View the different ways to contact CICA",
+                                        html: contact
+                                    })}}
                                     <h2 class="govuk-heading-m">Help us improve this service</h2>
                                     <p class="govuk-body">You can complete a short survey to help us improve this service.</p>
-                                    <p class="govuk-body">It does not ask for any details about your case and has no impact on your application.</p>
+                                    <p class="govuk-body">It does not ask for any details about your case and has no effect on your application.</p>
                                     <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.surveymonkey.com/r/Privatebetafeedback">Tell us what you think of our service (opens in new tab)</a> (takes 10 minutes)</p>
                                 `,
                                 mainapplicant: {
@@ -87,6 +88,9 @@ module.exports = {
                                         {% else %}
                                         {% set html =  "<p>We\'ll send your confirmation to <strong>" + contactMethod + "</strong> soon</p>" %}
                                         {% endif %}
+                                        {% set contact %}
+                                            {% include 'contact.njk' %}
+                                        {% endset %}
                                         <p class="govuk-body">All links on this page open in a new tab.</p>
                                         {{ govukPanel({
                                         titleText: "Application submitted",
@@ -100,7 +104,7 @@ module.exports = {
                                             <li>power of attorney document you’re named on</li>
                                             <li>court order showing you have legal authority to act on behalf of the victim</li>
                                         </ul>
-                                        <p class="govuk-body">To certify a document as a true copy of the original document, you need to get it signed and dated by someone in a professional capacity – such as a solicitor. <a href=https://www.gov.uk/certifying-a-document">Discover more information about certifying documents</a> if you’re still unsure about sending these to us.</p>
+                                        <p class="govuk-body">To certify a document as a true copy of the original document, you need to get it signed and dated by someone in a professional capacity – such as a solicitor. <a href=https://www.gov.uk/certifying-a-document">Discover more information about certifying documents (opens in new tab)</a> if you’re still unsure about sending these to us.</p>
                                         <p class="govuk-body">You should email your documents to us at <a href="mailto:centraladminaction@cica.gov.uk">centraladminaction@cica.gov.uk.</a></p>
                                         <p class="govuk-body">If you cannot send these documents by email, you can post them to us at:</p>
                                         <p class="govuk-body govuk-!-margin-bottom-1"><strong>Criminal Injuries Compensation Authority</strong></p>
@@ -135,19 +139,16 @@ module.exports = {
                                             <li>you have new information to add to your application</li>
                                             <li>information you provided previously has changed</li>
                                         </ul>
-                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.gov.uk/government/organisations/criminal-injuries-compensation-authority/about-our-services">Send an update about your application</a></p>
+                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://contact-the-cica.form.service.justice.gov.uk/">Send an update about your application</a></p>
                                         <h2 class="govuk-heading-m">Contact us</h2>
-                                        <p class="govuk-body govuk-!-margin-bottom-1">Email: <a href="mailto:info@cica.gov.uk" class="govuk-link">info@cica.gov.uk</a></p>
-                                        {% include \'contact.njk\' %}
-                                        <p class="govuk-body">We will not always send an acknowledgement if you:</p>
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>email us</li>
-                                            <li>write to us</li>
-                                            <li>send us documents</li>
-                                        </ul>
+                                        <p class="govuk-body">As we've only received this application, we will now carry out necessary initial enquiries relating to this. Unless you've anything new to add or update in the application, we kindly ask that you wait for us to contact you.</p>
+                                        {{ govukDetails({
+                                            summaryText: "View the different ways to contact CICA",
+                                            html: contact
+                                        })}}
                                         <h2 class="govuk-heading-m">Help us improve this service</h2>
                                         <p class="govuk-body">You can complete a short survey to help us improve this service.</p>
-                                        <p class="govuk-body">It does not ask for any details about your case and has no impact on your application.</p>
+                                        <p class="govuk-body">It does not ask for any details about your case and has no effect on your application.</p>
                                         <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.surveymonkey.com/r/Privatebetafeedback">Tell us what you think of our service (opens in new tab)</a> (takes 10 minutes)</p>
                                     `,
                                     child: `{% set mobilePhoneNumber = "||/answers/p-applicant-confirmation-method/q-applicant-enter-your-telephone-number||" %}
@@ -163,6 +164,9 @@ module.exports = {
                                         {% else %}
                                         {% set html =  "<p>We\'ll send your confirmation to <strong>" + contactMethod + "</strong> soon</p>" %}
                                         {% endif %}
+                                        {% set contact %}
+                                            {% include 'contact.njk' %}
+                                        {% endset %}
                                         <p class="govuk-body">All links on this page open in a new tab.</p>
                                         {{ govukPanel({
                                         titleText: "Application submitted",
@@ -217,19 +221,16 @@ module.exports = {
                                             <li>you have new information to add to your application</li>
                                             <li>information you provided previously has changed</li>
                                         </ul>
-                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.gov.uk/government/organisations/criminal-injuries-compensation-authority/about-our-services">Send an update about your application</a></p>
+                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://contact-the-cica.form.service.justice.gov.uk/">Send an update about your application</a></p>
                                         <h2 class="govuk-heading-m">Contact us</h2>
-                                        <p class="govuk-body govuk-!-margin-bottom-1">Email: <a href="mailto:info@cica.gov.uk" class="govuk-link">info@cica.gov.uk</a></p>
-                                        {% include \'contact.njk\' %}
-                                        <p class="govuk-body">We will not always send an acknowledgement if you:</p>
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>email us</li>
-                                            <li>write to us</li>
-                                            <li>send us documents</li>
-                                        </ul>
+                                        <p class="govuk-body">As we've only received this application, we will now carry out necessary initial enquiries relating to this. Unless you've anything new to add or update in the application, we kindly ask that you wait for us to contact you.</p>
+                                        {{ govukDetails({
+                                            summaryText: "View the different ways to contact CICA",
+                                            html: contact
+                                        })}}
                                         <h2 class="govuk-heading-m">Help us improve this service</h2>
                                         <p class="govuk-body">You can complete a short survey to help us improve this service.</p>
-                                        <p class="govuk-body">It does not ask for any details about your case and has no impact on your application.</p>
+                                        <p class="govuk-body">It does not ask for any details about your case and has no effect on your application.</p>
                                         <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.surveymonkey.com/r/Privatebetafeedback">Tell us what you think of our service (opens in new tab)</a> (takes 10 minutes)</p>
                                     `
                                 },
@@ -247,6 +248,9 @@ module.exports = {
                                         {% else %}
                                         {% set html =  "<p>We\'ll send your confirmation to <strong>" + contactMethod + "</strong> soon</p>" %}
                                         {% endif %}
+                                        {% set contact %}
+                                            {% include 'contact.njk' %}
+                                        {% endset %}
                                         <p class="govuk-body">All links on this page open in a new tab.</p>
                                         {{ govukPanel({
                                         titleText: "Application submitted",
@@ -278,19 +282,16 @@ module.exports = {
                                             <li>you have new information to add to your application</li>
                                             <li>information you provided previously has changed</li>
                                         </ul>
-                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.gov.uk/government/organisations/criminal-injuries-compensation-authority/about-our-services">Send an update about your application</a></p>
+                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://contact-the-cica.form.service.justice.gov.uk/">Send an update about your application</a></p>
                                         <h2 class="govuk-heading-m">Contact us</h2>
-                                        <p class="govuk-body govuk-!-margin-bottom-1">Email: <a href="mailto:info@cica.gov.uk" class="govuk-link">info@cica.gov.uk</a></p>
-                                        {% include \'contact.njk\' %}
-                                        <p class="govuk-body">We will not always send an acknowledgement if you:</p>
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>email us</li>
-                                            <li>write to us</li>
-                                            <li>send us documents</li>
-                                        </ul>
+                                        <p class="govuk-body">As we've only received this application, we will now carry out necessary initial enquiries relating to this. Unless you've anything new to add or update in the application, we kindly ask that you wait for us to contact you.</p>
+                                        {{ govukDetails({
+                                            summaryText: "View the different ways to contact CICA",
+                                            html: contact
+                                        })}}
                                         <h2 class="govuk-heading-m">Help us improve this service</h2>
                                         <p class="govuk-body">You can complete a short survey to help us improve this service.</p>
-                                        <p class="govuk-body">It does not ask for any details about your case and has no impact on your application.</p>
+                                        <p class="govuk-body">It does not ask for any details about your case and has no effect on your application.</p>
                                         <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.surveymonkey.com/r/Privatebetafeedback">Tell us what you think of our service (opens in new tab)</a> (takes 10 minutes)</p>
                                     `,
                                     child: `{% set mobilePhoneNumber = "||/answers/p-applicant-confirmation-method/q-applicant-enter-your-telephone-number||" %}
@@ -306,6 +307,9 @@ module.exports = {
                                         {% else %}
                                         {% set html =  "<p>We\'ll send your confirmation to <strong>" + contactMethod + "</strong> soon</p>" %}
                                         {% endif %}
+                                        {% set contact %}
+                                            {% include 'contact.njk' %}
+                                        {% endset %}
                                         <p class="govuk-body">All links on this page open in a new tab.</p>
                                         {{ govukPanel({
                                         titleText: "Application submitted",
@@ -361,19 +365,16 @@ module.exports = {
                                             <li>you have new information to add to your application</li>
                                             <li>information you provided previously has changed</li>
                                         </ul>
-                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.gov.uk/government/organisations/criminal-injuries-compensation-authority/about-our-services">Send an update about your application</a></p>
+                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://contact-the-cica.form.service.justice.gov.uk/">Send an update about your application</a></p>
                                         <h2 class="govuk-heading-m">Contact us</h2>
-                                        <p class="govuk-body govuk-!-margin-bottom-1">Email: <a href="mailto:info@cica.gov.uk" class="govuk-link">info@cica.gov.uk</a></p>
-                                        {% include \'contact.njk\' %}
-                                        <p class="govuk-body">We will not always send an acknowledgement if you:</p>
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>email us</li>
-                                            <li>write to us</li>
-                                            <li>send us documents</li>
-                                        </ul>
+                                        <p class="govuk-body">As we've only received this application, we will now carry out necessary initial enquiries relating to this. Unless you've anything new to add or update in the application, we kindly ask that you wait for us to contact you.</p>
+                                        {{ govukDetails({
+                                            summaryText: "View the different ways to contact CICA",
+                                            html: contact
+                                        })}}
                                         <h2 class="govuk-heading-m">Help us improve this service</h2>
                                         <p class="govuk-body">You can complete a short survey to help us improve this service.</p>
-                                        <p class="govuk-body">It does not ask for any details about your case and has no impact on your application.</p>
+                                        <p class="govuk-body">It does not ask for any details about your case and has no effect on your application.</p>
                                         <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.surveymonkey.com/r/Privatebetafeedback">Tell us what you think of our service (opens in new tab)</a> (takes 10 minutes)</p>
                                     `,
                                     noAuthority: `{% set mobilePhoneNumber = "||/answers/p-applicant-confirmation-method/q-applicant-enter-your-telephone-number||" %}
@@ -389,6 +390,9 @@ module.exports = {
                                         {% else %}
                                         {% set html =  "<p>We\'ll send your confirmation to <strong>" + contactMethod + "</strong> soon</p>" %}
                                         {% endif %}
+                                        {% set contact %}
+                                            {% include 'contact.njk' %}
+                                        {% endset %}
                                         <p class="govuk-body">All links on this page open in a new tab.</p>
                                         {{ govukPanel({
                                         titleText: "Application submitted",
@@ -402,8 +406,8 @@ module.exports = {
                                             <li>power of attorney document you’re named on</li>
                                             <li>court order showing you have legal authority to act on behalf of the victim</li>
                                         </ul>
-                                        <p class="govuk-body">To certify a document as a true copy of the original document, you need to get it signed and dated by someone in a professional capacity – such as a solicitor. <a href=https://www.gov.uk/certifying-a-document">Discover more information about certifying documents</a> if you’re still unsure about sending these to us.</p>
-                                        <p class="govuk-body">You should email your documents to us at <a href="mailto:centraladminaction@cica.gov.uk">centraladminaction@cica.gov.uk.</a></p>
+                                        <p class="govuk-body">To certify a document as a true copy of the original document, you need to get it signed and dated by someone in a professional capacity – such as a solicitor.</p>
+                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.gov.uk/certifying-a-document">Discover more information about certifying documents</a> if you’re still unsure about sending these to us.</p>
                                         <p class="govuk-body">If you cannot send these documents by email, you can post them to us at:</p>
                                         <p class="govuk-body govuk-!-margin-bottom-1"><strong>Criminal Injuries Compensation Authority</strong></p>
                                         <p class="govuk-body govuk-!-margin-bottom-1">Alexander Bain House</p>
@@ -437,19 +441,16 @@ module.exports = {
                                             <li>you have new information to add to your application</li>
                                             <li>information you provided previously has changed</li>
                                         </ul>
-                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.gov.uk/government/organisations/criminal-injuries-compensation-authority/about-our-services">Send an update about your application</a></p>
+                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://contact-the-cica.form.service.justice.gov.uk/">Send an update about your application</a></p>
                                         <h2 class="govuk-heading-m">Contact us</h2>
-                                        <p class="govuk-body govuk-!-margin-bottom-1">Email: <a href="mailto:info@cica.gov.uk" class="govuk-link">info@cica.gov.uk</a></p>
-                                        {% include \'contact.njk\' %}
-                                        <p class="govuk-body">We will not always send an acknowledgement if you:</p>
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>email us</li>
-                                            <li>write to us</li>
-                                            <li>send us documents</li>
-                                        </ul>
+                                        <p class="govuk-body">As we've only received this application, we will now carry out necessary initial enquiries relating to this. Unless you've anything new to add or update in the application, we kindly ask that you wait for us to contact you.</p>
+                                        {{ govukDetails({
+                                            summaryText: "View the different ways to contact CICA",
+                                            html: contact
+                                        })}}
                                         <h2 class="govuk-heading-m">Help us improve this service</h2>
                                         <p class="govuk-body">You can complete a short survey to help us improve this service.</p>
-                                        <p class="govuk-body">It does not ask for any details about your case and has no impact on your application.</p>
+                                        <p class="govuk-body">It does not ask for any details about your case and has no effect on your application.</p>
                                         <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.surveymonkey.com/r/Privatebetafeedback">Tell us what you think of our service (opens in new tab)</a> (takes 10 minutes)</p>
                                     `,
                                     incapableAdult: `{% set mobilePhoneNumber = "||/answers/p-applicant-confirmation-method/q-applicant-enter-your-telephone-number||" %}
@@ -465,6 +466,9 @@ module.exports = {
                                         {% else %}
                                         {% set html =  "<p>We\'ll send your confirmation to <strong>" + contactMethod + "</strong> soon</p>" %}
                                         {% endif %}
+                                        {% set contact %}
+                                            {% include 'contact.njk' %}
+                                        {% endset %}
                                         <p class="govuk-body">All links on this page open in a new tab.</p>
                                         {{ govukPanel({
                                         titleText: "Application submitted",
@@ -475,10 +479,10 @@ module.exports = {
                                         <h2 class="govuk-heading-m">Send certified documents to prove the person with legal authority can apply on the victim’s behalf</h2>
                                         <p class="govuk-body">This proof should be a certified copy of a:</p>
                                         <ul class="govuk-list govuk-list--bullet">
-                                            <li>power of attorney document you’re named on</li>
-                                            <li>court order showing you have legal authority to act on behalf of the victim</li>
+                                            <li>power of attorney document they’re named on</li>
+                                            <li>court order showing they have legal authority to act on behalf of the victim</li>
                                         </ul>
-                                        <p class="govuk-body">To certify a document as a true copy of the original document, you need to get it signed and dated by someone in a professional capacity – such as a solicitor. <a href=https://www.gov.uk/certifying-a-document">Discover more information about certifying documents</a> if you’re still unsure about sending these to us.</p>
+                                        <p class="govuk-body">To certify a document as a true copy of the original document, you need to get it signed and dated by someone in a professional capacity – such as a solicitor. <a href=https://www.gov.uk/certifying-a-document">Discover more information about certifying documents (opens in new tab)</a> if you’re still unsure about sending these to us.</p>
                                         <p class="govuk-body">You should email your documents to us at <a href="mailto:centraladminaction@cica.gov.uk">centraladminaction@cica.gov.uk.</a></p>
                                         <p class="govuk-body">If you cannot send these documents by email, you can post them to us at:</p>
                                         <p class="govuk-body govuk-!-margin-bottom-1"><strong>Criminal Injuries Compensation Authority</strong></p>
@@ -513,19 +517,16 @@ module.exports = {
                                             <li>you have new information to add to your application</li>
                                             <li>information you provided previously has changed</li>
                                         </ul>
-                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.gov.uk/government/organisations/criminal-injuries-compensation-authority/about-our-services">Send an update about your application</a></p>
+                                        <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://contact-the-cica.form.service.justice.gov.uk/">Send an update about your application</a></p>
                                         <h2 class="govuk-heading-m">Contact us</h2>
-                                        <p class="govuk-body govuk-!-margin-bottom-1">Email: <a href="mailto:info@cica.gov.uk" class="govuk-link">info@cica.gov.uk</a></p>
-                                        {% include \'contact.njk\' %}
-                                        <p class="govuk-body">We will not always send an acknowledgement if you:</p>
-                                        <ul class="govuk-list govuk-list--bullet">
-                                            <li>email us</li>
-                                            <li>write to us</li>
-                                            <li>send us documents</li>
-                                        </ul>
+                                        <p class="govuk-body">As we've only received this application, we will now carry out necessary initial enquiries relating to this. Unless you've anything new to add or update in the application, we kindly ask that you wait for us to contact you.</p>
+                                        {{ govukDetails({
+                                            summaryText: "View the different ways to contact CICA",
+                                            html: contact
+                                        })}}
                                         <h2 class="govuk-heading-m">Help us improve this service</h2>
                                         <p class="govuk-body">You can complete a short survey to help us improve this service.</p>
-                                        <p class="govuk-body">It does not ask for any details about your case and has no impact on your application.</p>
+                                        <p class="govuk-body">It does not ask for any details about your case and has no effect on your application.</p>
                                         <p class="govuk-body"><a class="govuk-link" target="_blank" href="https://www.surveymonkey.com/r/Privatebetafeedback">Tell us what you think of our service (opens in new tab)</a> (takes 10 minutes)</p>
                                     `
                                 }


### PR DESCRIPTION
Amend confirmation content. 

- Lint rule necessary as it thinks the escape chars are not needed - they are!
- Replaced govuk details nunjucks with transformed HTML. Necessary for correct use with `contact.njk` partial template