### PR TITLE
Add double-digit example to description

### DIFF
--- a/src/lib/resource/sections/applicant-enter-your-date-of-birth.js
+++ b/src/lib/resource/sections/applicant-enter-your-date-of-birth.js
@@ -57,7 +57,7 @@ module.exports = {
                     },
                     type: 'string',
                     format: 'date-time',
-                    description: 'For example, 31 3 1980.',
+                    description: 'For example, 31 12 1989.',
                     errorMessage: {
                         format:
                             'l10nt:q-applicant-enter-your-date-of-birth.error.format{?lng,context,ns}'


### PR DESCRIPTION
Include double-digit numbers in the date example to avoid confusion over entering left-padded digits.