### PR TITLE
Added text changes for those with and without legal authority when ap…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "q-templates-application",
-    "version": "9.0.2",
+    "version": "9.0.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "q-templates-application",
-            "version": "9.0.2",
+            "version": "9.0.3",
             "license": "MIT",
             "devDependencies": {
                 "ajv-formats-mobile-uk": "github:CriminalInjuriesCompensationAuthority/ajv-formats-mobile-uk#v1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-templates-application",
-    "version": "9.0.2",
+    "version": "9.0.3",
     "description": "Apply for compensation questionnaire template",
     "main": "dist/template.json",
     "engines": {

--- a/src/lib/resource/sections/confirmation.js
+++ b/src/lib/resource/sections/confirmation.js
@@ -98,7 +98,7 @@ module.exports = {
                                         })}}
                                         <p class="govuk-body">Thank you for submitting this application.</p>
                                         
-                                        <h2 class="govuk-heading-m">Send certified documents to prove you have the legal authority to apply on the victim’s behalf</h2>
+                                        <h2 class="govuk-heading-m">Send certified documents to prove you have the legal authority to act on the victim’s behalf</h2>
                                         <p class="govuk-body">This proof should be a certified copy of a:</p>
                                         <ul class="govuk-list govuk-list--bullet">
                                             <li>power of attorney document you’re named on</li>
@@ -318,7 +318,7 @@ module.exports = {
                                             })}}
                                             <p class="govuk-body">Thank you for submitting this application.</p>
                                             
-                                            <h2 class="govuk-heading-m">Send certified documents to prove the person with legal authority can apply on the victim’s behalf</h2>
+                                            <h2 class="govuk-heading-m">Send certified documents to prove the person with legal authority can act on the victim’s behalf</h2>
                                             <p class="govuk-body">This proof should be a certified copy of a:</p>
                                             <ul class="govuk-list govuk-list--bullet">
                                                 <li>power of attorney document they’re named on</li>
@@ -477,7 +477,7 @@ module.exports = {
                                         html: html
                                         })}}
                                         <p class="govuk-body">Thank you for submitting this application.</p>
-                                        <h2 class="govuk-heading-m">Send certified documents to prove the person with legal authority can apply on the victim’s behalf</h2>
+                                        <h2 class="govuk-heading-m">Send certified documents to prove who has legal authority to act on the victim’s behalf</h2>
                                         <p class="govuk-body">We understand this might not be confirmed as yet. Unfortunately, we’re unable to progress the application any further until we have these details though. You can send this to us at a later date.</p>
                                         <p class="govuk-body">This proof should be a certified copy of a:</p>
                                         <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
Three minor text changes for tickets below:

**Summary of change for CDS2-66**
The content of the confirmation screens was agreed before that of the Notifications. Some changes were made to the latter eg from apply on behalf of to act on behalf of the victim. This story is to make the necessary content changes to ensure it aligns with the Notification and legal requirement. Change ‘apply’ to ‘act’ as per screenshot below.

**Summary of change for CDS2-67**
The content of the confirmation screens was agreed before that of the Notifications. Some changes were made to the latter eg from apply on behalf of to act on behalf of the victim. This story is to make the necessary content changes to ensure it aligns with the Notification and legal requirement. Change ‘the person with legal authority can apply’ to ‘who has legal authority to act' as per screenshot below.

**Summary of change for CDS2-68**
The content of the confirmation screens was agreed before that of the Notifications. Some changes were made to the latter eg from apply on behalf of to act on behalf of the victim. This story is to make the necessary content changes to ensure it aligns with the Notification and legal requirement. Change ‘apply’ to ‘act' as per screenshot below.

