### PR TITLE
Changed help details for when a crime is reported to police or not

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "q-templates-application",
-    "version": "10.0.0",
+    "version": "10.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "q-templates-application",
-            "version": "10.0.0",
+            "version": "10.0.1",
             "license": "MIT",
             "devDependencies": {
                 "ajv-formats-mobile-uk": "github:CriminalInjuriesCompensationAuthority/ajv-formats-mobile-uk#v1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-templates-application",
-    "version": "10.0.0",
+    "version": "10.0.1",
     "description": "Apply for compensation questionnaire template",
     "main": "dist/template.json",
     "engines": {

--- a/src/lib/resource/sections/was-the-crime-reported-to-police.js
+++ b/src/lib/resource/sections/was-the-crime-reported-to-police.js
@@ -29,7 +29,7 @@ module.exports = {
                 },
                 'dont-know-if-crime-reported': {
                     description:
-                        '{% from "components/details/macro.njk" import govukDetails %}{% set templateHtml %}{% include \'contact.njk\' %}{% endset %}{{ govukDetails({summaryText: "I do not know if the crime was reported to the police",html: \'<p class="govuk-body">You can contact us for help with your application.</p>\' + templateHtml})}}'
+                        '{% from "components/details/macro.njk" import govukDetails %}{% set templateHtml %}{% include \'contact.njk\' %}{% endset %}{{ govukDetails({summaryText: "I do not know if the crime was reported to the police",html: \'<p class="govuk-body">If you do not know if the crime was reported to the police, call 101 to speak to your local police station. They can help you with this.</p>\'})}}'
                 }
             },
             errorMessage: {


### PR DESCRIPTION
https://dsdmoj.atlassian.net/jira/software/c/projects/CDS2/boards/994?modal=detail&selectedIssue=CDS2-139

Hint text tells users to contact us for help but we ask them to contact the police on 101. Change hint text to

If you do not know if the crime was reported to the police, call 101 to speak to your local police station. They can help you with this.

This came out of user research with our colleagues in CST and is a frustration for staff and applicants