### PR TITLE
Bug/cds2 185/deceased journey routing fix

### DIFF
--- a/src/lib/resource/sections/applicant-where-in-england-did-it-happen.js
+++ b/src/lib/resource/sections/applicant-where-in-england-did-it-happen.js
@@ -97,7 +97,27 @@ module.exports = {
             ANSWER: [
                 {
                     target: 'p--which-police-force-is-investigating-the-crime',
-                    cond: ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true]
+                    cond: [
+                        'and',
+                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        [
+                            '==',
+                            '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',
+                            true
+                        ]
+                    ]
+                },
+                {
+                    target: 'p-applicant-immediate-aftermath',
+                    cond: [
+                        'and',
+                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        [
+                            '==',
+                            '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',
+                            false
+                        ]
+                    ]
                 },
                 {
                     target: 'p-applicant-describe-incident',

--- a/src/lib/resource/sections/applicant-where-in-england-did-it-happen.js
+++ b/src/lib/resource/sections/applicant-where-in-england-did-it-happen.js
@@ -99,7 +99,7 @@ module.exports = {
                     target: 'p--which-police-force-is-investigating-the-crime',
                     cond: [
                         'and',
-                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        ['|role.all', 'deceased'],
                         [
                             '==',
                             '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',
@@ -111,7 +111,7 @@ module.exports = {
                     target: 'p-applicant-immediate-aftermath',
                     cond: [
                         'and',
-                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        ['|role.all', 'deceased'],
                         [
                             '==',
                             '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',

--- a/src/lib/resource/sections/applicant-where-in-scotland-did-it-happen.js
+++ b/src/lib/resource/sections/applicant-where-in-scotland-did-it-happen.js
@@ -102,7 +102,7 @@ module.exports = {
                     target: 'p--which-police-force-is-investigating-the-crime',
                     cond: [
                         'and',
-                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        ['|role.all', 'deceased'],
                         [
                             '==',
                             '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',
@@ -114,7 +114,7 @@ module.exports = {
                     target: 'p-applicant-immediate-aftermath',
                     cond: [
                         'and',
-                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        ['|role.all', 'deceased'],
                         [
                             '==',
                             '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',

--- a/src/lib/resource/sections/applicant-where-in-scotland-did-it-happen.js
+++ b/src/lib/resource/sections/applicant-where-in-scotland-did-it-happen.js
@@ -100,7 +100,27 @@ module.exports = {
             ANSWER: [
                 {
                     target: 'p--which-police-force-is-investigating-the-crime',
-                    cond: ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true]
+                    cond: [
+                        'and',
+                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        [
+                            '==',
+                            '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',
+                            true
+                        ]
+                    ]
+                },
+                {
+                    target: 'p-applicant-immediate-aftermath',
+                    cond: [
+                        'and',
+                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        [
+                            '==',
+                            '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',
+                            false
+                        ]
+                    ]
                 },
                 {
                     target: 'p-applicant-describe-incident',

--- a/src/lib/resource/sections/applicant-where-in-wales-did-it-happen.js
+++ b/src/lib/resource/sections/applicant-where-in-wales-did-it-happen.js
@@ -97,7 +97,27 @@ module.exports = {
             ANSWER: [
                 {
                     target: 'p--which-police-force-is-investigating-the-crime',
-                    cond: ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true]
+                    cond: [
+                        'and',
+                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        [
+                            '==',
+                            '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',
+                            true
+                        ]
+                    ]
+                },
+                {
+                    target: 'p-applicant-immediate-aftermath',
+                    cond: [
+                        'and',
+                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        [
+                            '==',
+                            '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',
+                            false
+                        ]
+                    ]
                 },
                 {
                     target: 'p-applicant-describe-incident',

--- a/src/lib/resource/sections/applicant-where-in-wales-did-it-happen.js
+++ b/src/lib/resource/sections/applicant-where-in-wales-did-it-happen.js
@@ -99,7 +99,7 @@ module.exports = {
                     target: 'p--which-police-force-is-investigating-the-crime',
                     cond: [
                         'and',
-                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        ['|role.all', 'deceased'],
                         [
                             '==',
                             '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',
@@ -111,7 +111,7 @@ module.exports = {
                     target: 'p-applicant-immediate-aftermath',
                     cond: [
                         'and',
-                        ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                        ['|role.all', 'deceased'],
                         [
                             '==',
                             '$.answers.p--was-the-crime-reported-to-police.q--was-the-crime-reported-to-police',


### PR DESCRIPTION
- Remove loop involving crime reference number

The issue was caused by the applicant being asked which police force is investigating the crime even if they previously said the crime had not been reported to the police. Now, if the crime was not reported to the police, the police force question and subsequent reference number questions are skipped.