### PR TITLE
Changed condition for rep routing from 'or' to 'and' for care order authority

### DIFF
--- a/src/lib/resource/sections/mainapplicant-care-order-authority.js
+++ b/src/lib/resource/sections/mainapplicant-care-order-authority.js
@@ -59,7 +59,7 @@ module.exports = {
                 {
                     target: 'p--context-rep-details',
                     cond: [
-                        'or',
+                        'and',
                         ['==', '$.answers.p-mainapplicant-parent.q-mainapplicant-parent', false],
                         ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', false]
                     ]


### PR DESCRIPTION
Changed condition for rep routing from 'or' to 'and' for care order authority