### PR TITLE
Fix/remove incident property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "q-templates-application",
-    "version": "12.0.22",
+    "version": "12.0.23",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "q-templates-application",
-            "version": "12.0.22",
+            "version": "12.0.23",
             "license": "MIT",
             "devDependencies": {
                 "ajv-formats-mobile-uk": "github:CriminalInjuriesCompensationAuthority/ajv-formats-mobile-uk#v1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-templates-application",
-    "version": "12.0.22",
+    "version": "12.0.23",
     "description": "Apply for compensation questionnaire template",
     "main": "dist/template.json",
     "engines": {

--- a/src/lib/resource/sections/applicant-describe-incident.js
+++ b/src/lib/resource/sections/applicant-describe-incident.js
@@ -21,6 +21,8 @@ module.exports = {
                 'q-applicant-describe-incident': {
                     type: 'boolean',
                     title: 'Do you want to tell us about the crime?',
+                    description:
+                        'The police will send us a report of the crime. Providing an additional description is optional.',
                     oneOf: [
                         {
                             title: 'Yes',


### PR DESCRIPTION
Add description back to `q-applicant-describe-incident` to remove need for the `describe-incident-info` property