### PR TITLE
Change hook to only run test on source file changes

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -2,7 +2,7 @@
 const config = {
     hooks: {
         'pre-commit': 'lint-staged',
-        'pre-commit': 'npm run test'
+        'pre-commit': 'npm run test:src'
     }
 };
 /*! m0-end */

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     },
     "scripts": {
         "pretest": "npm run build",
+        "test:src": "git diff --cached --name-only > temp.txt && (node -e \"if(fs.readFileSync('temp.txt',{encoding:'utf8'}).includes('src')){process.exit(1)}else{console.log('Template files unchanged, skipping build tests')} \" || npm run test) && npx rimraf ./temp.txt",
         "test": "jest",
         "coverage": "jest --coverage",
         "lint": "eslint .",


### PR DESCRIPTION
Adds a check to the precommit test hook so that build tests are only ran when the template files actually change. This will stop jest from running every time a commit is made to the feature files, allowing people who haven't npm installed to commit changes